### PR TITLE
bug fix in the way that Path's are formatted inside of the toml writer.

### DIFF
--- a/comprehensiveconfig/toml.py
+++ b/comprehensiveconfig/toml.py
@@ -75,10 +75,12 @@ class TomlWriter(configio.ConfigurationWriter):
         match value:
             case bool():
                 return "true" if value else "false"
-            case int() | float() | Path():
+            case int() | float():
                 return str(value)
             case str():
                 return f'"{escape(value)}"'
+            case Path():
+                return f'"{escape(str(value).replace("\\", "/"))}"'
             case list():
                 return f"[{", ".join([str(cls.format_value(field, inner_val)) for inner_val in value])}]"
             case dict():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "comprehensiveconfig"
-version = "1.2.0"
+version = "1.2.1"
 description = "A library to create ergonomic, auto-validated configuration models with great support for static type annotations."
 readme = "readme.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
# Description

Fixes a bug that completely broke saving paths if they weren't originally strings.